### PR TITLE
[hotfix/updateNode] Fix problems with build because of old node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bin/
 
 node/
 node_modules/
+npm-debug.log

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
   <properties>
     <!-- https://github.com/jenkinsci/acceptance-test-harness -->
     <jenkins.acceptance.testharness.version>1.30</jenkins.acceptance.testharness.version>
-    <node.version>5.8.0</node.version>
-    <npm.version>3.7.3</npm.version>
+    <node.version>6.4.0</node.version>
+    <npm.version>3.10.3</npm.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
# Description

The ci fails on the pre-installation of nodegit, which is caused by the old version we use.

@jenkinsci/code-reviewers @reviewbybees 

