### PR TITLE
Use repo.jenkins-ci.org from Maven plugins too

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
This is in order to ensure everything comes from Jenkins repository and to be able use the cache for CI

@jenkinsci/code-reviewers @reviewbybees 

