### PR TITLE
Changes needed for upgrade to declarative plugin 0.6

### DIFF
--- a/src/test/resources/test_scripts/stages-with-wait-pipelineModel-syntax.groovy
+++ b/src/test/resources/test_scripts/stages-with-wait-pipelineModel-syntax.groovy
@@ -2,15 +2,19 @@ pipeline {
   agent label:""
   stages {
     stage ('Stage 1'){
+      steps{
            sh 'sleep 6; echo `date` Stage 1;'
            sh 'sleep 6; echo `date` Stage 1;'
-       }
+         }
+      }
 
-        stage ('fin'){
+      stage ('fin'){
+        steps{
             sh 'echo `date` fin;sleep 3; echo `date` fin;'
             sh 'echo yeah > foo.txt'
             archiveArtifacts 'foo.txt'
         }
+      }
   }
 
 }


### PR DESCRIPTION
# Description

@tfennelly @scherler 
I have a PR to integrate pipeline-model-definition (declarative plugin) version to 0.6. See https://github.com/jenkinsci/blueocean-plugin/pull/594. This will break ATH as some of the syntax has changed. so this PR is for that.

This is the only test I found that was written using declarative syntax. In case I missed some, please point me to them for changes or you can change yourself.




See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

…e 'steps' element.

It fixes following error:

WorkflowScript: 9: Unknown stage section 'sh'. Starting with version 0.5, steps in a stage must be in a 'steps' block. @ line 9, column 7.
         stage ('fin'){