### PR TITLE
[FIX JENKINS-39809_404_pages_appear_only_in_pipelinePage_children] 

### DIFF
--- a/src/main/js/page_objects/blueocean/blueNotFound.js
+++ b/src/main/js/page_objects/blueocean/blueNotFound.js
@@ -1,0 +1,28 @@
+/** @module blueNotFound
+ * @memberof page_objects
+ * @description Represents the default 404 page in blueocean
+ *
+ * @example
+ *   browser.page.blueNotFound().xxx();
+ * */
+module.exports = {
+    elements: {
+        fullscreenDiv: '.fullscreen.not-found',
+        title: '.fullscreen.not-found .message-box h3',
+        message: '.fullscreen.not-found .message-box .message',
+        link: '.fullscreen.not-found .message-box .actions a',
+    }
+};
+module.exports.commands = [{
+  /**
+   * Different test on general elements that should be visible on the page
+   * @returns {Object} self - nightwatch page object
+   */
+  assertBasicLayoutOkay: function () {
+    this.waitForElementVisible('@fullscreenDiv');
+    this.waitForElementVisible('@title');
+    this.waitForElementVisible('@message');
+    this.waitForElementVisible('@link');
+  },
+
+}];

--- a/src/main/js/page_objects/blueocean/blueNotFound.js
+++ b/src/main/js/page_objects/blueocean/blueNotFound.js
@@ -3,7 +3,7 @@
  * @description Represents the default 404 page in blueocean
  *
  * @example
- *   browser.page.blueNotFound().xxx();
+ *   browser.page.blueNotFound().assertBasicLayoutOkay();
  * */
 module.exports = {
     elements: {

--- a/src/main/js/page_objects/blueocean/blueNotFound.js
+++ b/src/main/js/page_objects/blueocean/blueNotFound.js
@@ -18,11 +18,11 @@ module.exports.commands = [{
    * Different test on general elements that should be visible on the page
    * @returns {Object} self - nightwatch page object
    */
-  assertBasicLayoutOkay: function () {
+  assertBasicLayoutOkay: function (callback) {
     this.waitForElementVisible('@fullscreenDiv');
     this.waitForElementVisible('@title');
     this.waitForElementVisible('@message');
-    this.waitForElementVisible('@link');
+    this.waitForElementVisible('@link', callback);
   },
 
 }];

--- a/src/test/js/smoke.js
+++ b/src/test/js/smoke.js
@@ -1,14 +1,18 @@
 /** @module smoke
  * @memberof testcases
- * @description TEST: basic tests around the pipeline.
+ * @description TEST: basic tests around the pipeline. This includes creating and running a pipeline job, validating
+ * the activity view for empty and populated state. Further we validate the detail page with very basic matchers.
+ * We then try to press the "run" button on the activities tab and validate the Toast.
+ * To wrap up we are trying different urls which should result in 404 pages.
  */
+const async = require("async");
 module.exports = {
     /**
      * Create Pipeline Job
      * @param browser
      */
     'Step 01': function (browser) {
-        var pipelinesCreate = browser.page.pipelineCreate().navigate();
+        const pipelinesCreate = browser.page.pipelineCreate().navigate();
         pipelinesCreate.createPipeline('my-pipeline', 'three-stages.groovy');
     },
 
@@ -17,8 +21,8 @@ module.exports = {
      * @param browser
      */
     'Step 02': function (browser) {
-        var bluePipelineActivity = browser.page.bluePipelineActivity();
-        var bluePipelinesPage = browser.page.bluePipelines();
+        const bluePipelineActivity = browser.page.bluePipelineActivity();
+        const bluePipelinesPage = browser.page.bluePipelines();
 
         // make sure the open blue ocean button works. In this case,
         // it should bring the browser to an empty pipeline activity
@@ -37,7 +41,7 @@ module.exports = {
      * @param browser
      */
     'Step 03': function (browser) {
-        var blueActivityPage = browser.page.bluePipelineActivity().forJob('my-pipeline', 'jenkins');
+        const blueActivityPage = browser.page.bluePipelineActivity().forJob('my-pipeline', 'jenkins');
         
         blueActivityPage.assertBasicLayoutOkay();
         blueActivityPage.waitForElementVisible('@emptyStateShoes');
@@ -48,7 +52,7 @@ module.exports = {
      * @param browser
      */
     'Step 04': function (browser) {
-        var pipelinePage = browser.page.jobUtils().forJob('my-pipeline');
+        const pipelinePage = browser.page.jobUtils().forJob('my-pipeline');
         pipelinePage.build(function() {
             // Reload the job page and check that there was a build done.
             pipelinePage = browser.page.jobUtils().forJob('my-pipeline');
@@ -61,7 +65,7 @@ module.exports = {
      * @param browser
      */
     'Step 05': function (browser) {
-        var blueActivityPage = browser.page.bluePipelineActivity().forJob('my-pipeline', 'jenkins');
+        const blueActivityPage = browser.page.bluePipelineActivity().forJob('my-pipeline', 'jenkins');
         
         blueActivityPage.assertBasicLayoutOkay();
         blueActivityPage.expect.element('@emptyStateShoes').to.not.be.present.before(1000);
@@ -75,7 +79,7 @@ module.exports = {
      * @param browser
      */
     'Step 06': function (browser) {
-        var blueRunDetailPage = browser.page.bluePipelineRunDetail().forRun('my-pipeline', 'jenkins', 1);
+        const blueRunDetailPage = browser.page.bluePipelineRunDetail().forRun('my-pipeline', 'jenkins', 1);
         
         blueRunDetailPage.assertBasicLayoutOkay();
     },
@@ -87,10 +91,27 @@ module.exports = {
      * @param browser
      */
     'Step 07': function (browser) {
-        var blueActivityPage = browser.page.bluePipelineActivity().forJob('my-pipeline', 'jenkins');
+        const blueActivityPage = browser.page.bluePipelineActivity().forJob('my-pipeline', 'jenkins');
         blueActivityPage.clickRunButtonAndOpenDetail();
         // Check the run itself
         browser.page.bluePipelineRunDetail().assertBasicLayoutOkay();
+    },
+
+    /**
+     * Trying out different urls that should result in the same 404 page
+     * @param browser
+     */
+    'Step 08': function (browser) {
+        // test different levels for 404
+        var urls = ['/blue/gibtEsNicht', '/blue/organizations/gibtEsNicht', '/blue/organizations/gibtEsNicht/gibtEsNicht/detail/gibtEsNicht/'];
+        async.mapSeries(urls, function (url, callback) {
+            console.log('trying url', url);
+            // navigate to the url
+            browser.url(url, function(result) {
+                console.log(result)
+                browser.page.blueNotFound().assertBasicLayoutOkay();
+            });
+        });
     }
 
 };

--- a/src/test/js/smoke.js
+++ b/src/test/js/smoke.js
@@ -6,6 +6,8 @@
  * To wrap up we are trying different urls which should result in 404 pages.
  */
 const async = require("async");
+const pageHelper = require("../../main/js/util/pageHelper");
+const createCallbackWrapper = pageHelper.createCallbackWrapper;
 module.exports = {
     /**
      * Create Pipeline Job
@@ -52,7 +54,7 @@ module.exports = {
      * @param browser
      */
     'Step 04': function (browser) {
-        const pipelinePage = browser.page.jobUtils().forJob('my-pipeline');
+        var pipelinePage = browser.page.jobUtils().forJob('my-pipeline');
         pipelinePage.build(function() {
             // Reload the job page and check that there was a build done.
             pipelinePage = browser.page.jobUtils().forJob('my-pipeline');
@@ -103,13 +105,15 @@ module.exports = {
      */
     'Step 08': function (browser) {
         // FIXME: we need to test runs that not yet exist
+        // add the following as soon we have fixed them
+        // '/blue/organizations/gibtEsNicht', '/blue/organizations/jenkins/my-pipeline/detail/my-pipeline/20/pipeline'
         // test different levels for 404
-        var urls = ['/blue/gibtEsNicht', '/blue/organizations/gibtEsNicht', '/blue/organizations/gibtEsNicht/gibtEsNicht/detail/gibtEsNicht/'];
+        var urls = ['/blue/gibtEsNicht', '/blue/organizations/jenkins/gibtEsNicht/activity/', '/blue/organizations/gibtEsNicht/gibtEsNicht/detail/gibtEsNicht/'];
         async.mapSeries(urls, function (url, callback) {
-            console.log('trying url', url);
+            console.log('trying url', browser.launchUrl, url);
             // navigate to the url
-            browser.url(url, function(result) {
-                browser.page.blueNotFound().assertBasicLayoutOkay();
+            browser.url(browser.launchUrl + url, function(result) {
+                browser.page.blueNotFound().assertBasicLayoutOkay(createCallbackWrapper(callback));
             });
         });
     }

--- a/src/test/js/smoke.js
+++ b/src/test/js/smoke.js
@@ -102,13 +102,13 @@ module.exports = {
      * @param browser
      */
     'Step 08': function (browser) {
+        // FIXME: we need to test runs that not yet exist
         // test different levels for 404
         var urls = ['/blue/gibtEsNicht', '/blue/organizations/gibtEsNicht', '/blue/organizations/gibtEsNicht/gibtEsNicht/detail/gibtEsNicht/'];
         async.mapSeries(urls, function (url, callback) {
             console.log('trying url', url);
             // navigate to the url
             browser.url(url, function(result) {
-                console.log(result)
                 browser.page.blueNotFound().assertBasicLayoutOkay();
             });
         });


### PR DESCRIPTION
# Description

See [JENKINS-39809](https://issues.jenkins-ci.org/browse/JENKINS-39809).

Testing 404 pages.

@jenkinsci/code-reviewers @reviewbybees 

Add notFound page. Better description of test case. Add 404 tests for different urls.