### PR TITLE
Don't add jenkinsci/code-reviewers to all PRs

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -13,4 +13,4 @@ See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).
 - [ ] Reviewed the code
 - [ ] Verified that the appropriate tests have been written or valid explanation given
 
-@jenkinsci/code-reviewers @reviewbybees 
+@reviewbybees 


### PR DESCRIPTION
The idea of **jenkinsci/code-reviewers** is to have someone to ask for code reviews if they wouldn't happen otherwise. Lack of code reviewers can be a problem for 'lone wolf' plugin maintainers, especially when doing large scale changes, or integrating with new systems like Pipeline.

Making the ping to code-reviewers the default in this repo, especially with reviews clearly happening quickly in the BO team, runs counter to that goal and just makes reviewer volunteers ignore notifications.

@i386 Corresponding change to https://github.com/jenkinsci/blueocean-plugin/commit/f0e9fde8c34a6bc491d31fec2cc5fcd7c561cd39