### PR TITLE
Add a small wait in the Jenkinsfile used by multibranch/testResults.js

### DIFF
--- a/src/test/resources/multibranch/test_results/Jenkinsfile
+++ b/src/test/resources/multibranch/test_results/Jenkinsfile
@@ -6,7 +6,9 @@ node {
     // Need a small wait here so as not to hit JENKINS-36408.
     // Without it, the build run SSE end events *can* arrive at the client
     // before the it has finished processing the earlier events, which means
-    // the end events are meaningless to it.
+    // the end events are meaningless to it (no proper context until earlier
+    // events are processed), causing the UI state for that run to end up in
+    // limbo state - constant spinning orb etc requiring a page reload to fix.
     //
     sleep 2
 

--- a/src/test/resources/multibranch/test_results/Jenkinsfile
+++ b/src/test/resources/multibranch/test_results/Jenkinsfile
@@ -1,6 +1,16 @@
 node {
     stage 'Stage 1 - scm'
     echo 'Stage 1 - scm'
+
+    //
+    // Need a small wait here so as not to hit JENKINS-36408.
+    // Without it, the build run SSE end events *can* arrive at the client
+    // before the it has finished processing the earlier events, which means
+    // the end events are meaningless to it.
+    //
+    sleep 2
+
+
     checkout scm
     stage 'Stage test'
     echo 'stuff'


### PR DESCRIPTION
# Description

This is to ensure we don't hit random flaky fails due to [JENKINS-36408](https://issues.jenkins-ci.org/browse/JENKINS-36408).

ATH test runs: https://ci.blueocean.io/job/ATH-Jenkinsfile/job/JENKINS-39625-part2/ (from build number 8).

@reviewbybees 