### PR TITLE
task/jenkins 40256 use a semantic selector for "New Pipeline" button

### DIFF
--- a/src/test/js/i18n/loadGerman.js
+++ b/src/test/js/i18n/loadGerman.js
@@ -1,4 +1,6 @@
 const jobName = 'loadGerman';
+const newButtonSelector = '.btn-new-pipeline';
+
 /** @module loadGerman
  * @memberof i18n
  * @description basic smoke test for i18n
@@ -7,8 +9,8 @@ module.exports = {
     /** Load it in German */
     'Step 01': function (browser) {
         var bluePipelines = browser.page.bluePipelines().navigateLanguage("de");
-        bluePipelines.waitForElementVisible('.btn-secondary.inverse');
-        browser.getText('.btn-secondary.inverse', function(response) {            
+        bluePipelines.waitForElementVisible(newButtonSelector);
+        browser.getText(newButtonSelector, function(response) {
             browser.assert.equal(response.value, 'Neue Pipeline');
         });        
     },
@@ -16,8 +18,8 @@ module.exports = {
     /** Load it in The Queens English, God Bless The Queen */
     'Step 02': function (browser) {
         var bluePipelines = browser.page.bluePipelines().navigateLanguage("en");
-        bluePipelines.waitForElementVisible('.btn-secondary.inverse');
-        browser.getText('.btn-secondary.inverse', function(response) {            
+        bluePipelines.waitForElementVisible(newButtonSelector);
+        browser.getText(newButtonSelector, function(response) {
             browser.assert.equal(response.value, 'New Pipeline');
         });        
     },


### PR DESCRIPTION
# Description
- As some of the styling changed in jenkinsci/blueocean-plugin#666 the selectors became invalid. Added a new "semantic" class name that is less brittle.
- See [JENKINS-40256](https://issues.jenkins-ci.org/browse/JENKINS-40256).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
