### PR TITLE
[FIX JENKINS-40137] Test for: Fix encoding of job name in "Open Blue Ocean" URLs

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -76,11 +76,14 @@ if [ "${DEV_JENKINS}" == "true" ]; then
     echo "*****"
     echo "***** Starting a test dev instance of Jenkins with the blueocean plugins."
     echo "***** Watch console output for the URL to use while developing your test."
+    echo "***** You can debug the Jenkins instance on port 15000."
     echo "*****"
     echo "***** Be sure your test doesn't use JenkinsAcceptanceTestRule in any way"
     echo "***** or you'll be defeating the purpose (e.g. via AbstractJUnitTest)."
     echo "*****"
     echo ""
+
+    JENKINS_JAVA_OPTS="${JENKINS_JAVA_OPTS} -Xrunjdwp:transport=dt_socket,server=y,address=15000,suspend=n"
     
     # Exclude the actual tests from this run and just run the skeleton test in
     # ExcludedRunnerTest. It will just run with the plugins and stay running

--- a/src/test/java/utils/DevRunner.java
+++ b/src/test/java/utils/DevRunner.java
@@ -42,6 +42,9 @@ public class DevRunner extends BOJUnitTest {
         System.out.println("    You should now be able to develop tests against this instance without");
         System.out.println("    having to constantly restart Jenkins.");
         System.out.println("");
+        System.out.println("    You should be able to connect your debugger to your running Jenkins.");
+        System.out.println("    instance on port 15000.");
+        System.out.println("");
         System.out.println("    Open another terminal and run nightwatchjs commands to run specific tests.");
         System.out.println("    Iterate and rerun tests.");
         System.out.println("    See http://nightwatchjs.org/");

--- a/src/test/js/edgeCases/folder.js
+++ b/src/test/js/edgeCases/folder.js
@@ -197,6 +197,11 @@ module.exports = {
         browser.url(function (response) {
            sanityCheck(browser, response);
            response.value.endsWith('/blue/organizations/jenkins/anotherFolder%2F三百%2Fñba%2F七%2FSohn/detail/feature%2F1/1/pipeline');
+
+            // Make sure the page has all the bits and bobs
+            // See JENKINS-40137
+            const blueRunDetailPage = browser.page.bluePipelineRunDetail();
+            blueRunDetailPage.assertBasicLayoutOkay();
         });
     },
 };


### PR DESCRIPTION
# Description

See [JENKINS-40137](https://issues.jenkins-ci.org/browse/JENKINS-40137).

Test tweak for https://github.com/jenkinsci/blueocean-plugin/pull/676

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
