### PR TITLE
Bug/jenkins 40662 run details close problem

### DIFF
--- a/src/main/js/custom_commands/index.js
+++ b/src/main/js/custom_commands/index.js
@@ -9,4 +9,5 @@
  * @see {@link module:custom_commands.waitForJobDeleted}
  * @see {@link module:custom_commands.waitForJobRunEnded}
  * @see {@link module:custom_commands.waitForJobRunStarted}
+ * @see {@link module:custom_commands.waitForLocationChange}
  */

--- a/src/main/js/custom_commands/waitForLocationChange.js
+++ b/src/main/js/custom_commands/waitForLocationChange.js
@@ -1,0 +1,60 @@
+/**
+ * @module waitForLocationChange
+ * @memberof custom_commands
+ */
+const util = require('util');
+const events = require('events');
+
+function Cmd() {
+    events.EventEmitter.call(this);
+}
+util.inherits(Cmd, events.EventEmitter);
+
+var POLLING_FREQUENCY = 100;
+var TIMEOUT = 5000;
+
+/**
+ * @description Nightwatch command to wait for the browser's href to change.
+ * Polls the browser at a given frequency to wait for any change to location.href
+ */
+const waitForLocationChange = function () {
+    var self = this;
+    // var startTime = new Date().getTime();
+    var locationPollingTimeout = null;
+
+    self.api.url(function(response) {
+        var initialHref = response.value;
+
+        var checkForUrlChange = function() {
+            self.api.url(function (response) {
+                if (response.value !== initialHref) {
+                    // var ellapsed = new Date().getTime() - startTime;
+                    // console.log('url changed from: ' + initialHref + ' to: ' + response.value + 'after ' + ellapsed + ' milliseconds.');
+                    cleanUp();
+                    self.emit('complete');
+                }
+                else {
+                    locationPollingTimeout = setTimeout(checkForUrlChange, POLLING_FREQUENCY);
+                }
+            });
+        };
+
+        var errorTimeout = setTimeout(function() {
+            cleanUp();
+            var error = new Error('timed out waiting for location change');
+            self.emit('error', error);
+        }, TIMEOUT);
+
+        var cleanUp = function() {
+            clearTimeout(locationPollingTimeout);
+            clearTimeout(errorTimeout);
+        };
+
+        checkForUrlChange();
+    });
+
+    return this;
+};
+
+Cmd.prototype.command = waitForLocationChange;
+module.exports = Cmd;

--- a/src/main/js/page_objects/blueocean/bluePipelineRunDetail.js
+++ b/src/main/js/page_objects/blueocean/bluePipelineRunDetail.js
@@ -143,21 +143,20 @@ module.exports.commands = [{
     },
    /**
      * Close the modal view
+     * @param {String} [urlFragment] expected URL fragment to test for after close.
      * @returns {Object} self - nightwatch page object
      */
-    closeModal: function () {
+    closeModal: function (urlFragment) {
         const self = this;
         const browser = self.api;
         self.waitForElementVisible('@closeButton');
         self.click('@closeButton');
-        browser.url(function (response) {
-            sanityCheck(self, response);
-            // FIXME JENKINS-36619 -> somehow the close in AT is not working as it should
-            // I debugged a bit and found out that the "previous" location is the same as
-            // current, this is the reason, why no url change is triggered. The question remains
-            // why that is happening
-            // this.pause(10000)
-        });
+
+        if (urlFragment) {
+            self.waitForLocationChange();
+            browser.assert.urlContains(urlFragment);
+        }
+
         return self;
     },
     /**

--- a/src/main/js/page_objects/blueocean/bluePipelineRunDetail.js
+++ b/src/main/js/page_objects/blueocean/bluePipelineRunDetail.js
@@ -151,9 +151,9 @@ module.exports.commands = [{
         const browser = self.api;
         self.waitForElementVisible('@closeButton');
         self.click('@closeButton');
+        self.waitForLocationChange();
 
         if (urlFragment) {
-            self.waitForLocationChange();
             browser.assert.urlContains(urlFragment);
         }
 

--- a/src/test/js/edgeCases/runDetailsDeepLink.js
+++ b/src/test/js/edgeCases/runDetailsDeepLink.js
@@ -1,0 +1,38 @@
+/**
+ * @module runDetailsDeepLink
+ * @memberof edgeCases
+ * @description
+ *
+ * Tests: test whether navigating to Run Details without specifying a tab allows the close button to work correctly.
+ *
+ * REGRESSION covered:
+ *
+ * @see {@link https://issues.jenkins-ci.org/browse/JENKINS-40662|JENKINS-40662} Deep-linking to Run Details
+ * screen with no tab specified causes problem when closing modal
+ */
+const jobName = 'runDetailsDeepLink';
+module.exports = {
+    /** Create Pipeline Job "runDetailsDeepLink" */
+    'Step 01': function (browser) {
+        const pipelinesCreate = browser.page.pipelineCreate().navigate();
+        pipelinesCreate.createPipeline(jobName, 'initialStage.groovy');
+    },
+    /** Build Pipeline Job*/
+    'Step 02': function (browser) {
+        const pipelinePage = browser.page.jobUtils().forJob(jobName);
+        pipelinePage.buildStarted(function () {
+            // Reload the job page and check that there was a build done.
+            pipelinePage
+                .waitForElementVisible('div#pipeline-box')
+                .forRun(1)
+                .waitForElementVisible('@executer');
+        });
+    },
+    /** Check Job Blue Ocean Pipeline Activity Page has run */
+    'Step 03': function (browser) {
+        const blueActivityPage = browser.page.bluePipelineActivity().forJob(jobName, 'jenkins');
+        blueActivityPage.waitForRunRunningVisible(jobName + '-1');
+        const blueRunDetailPage = browser.page.bluePipelineRunDetail().forRun(jobName, 'jenkins', 1);
+        blueRunDetailPage.closeModal('/activity');
+    },
+};

--- a/src/test/js/edgeCases/runDetailsDeepLink.js
+++ b/src/test/js/edgeCases/runDetailsDeepLink.js
@@ -33,6 +33,7 @@ module.exports = {
         const blueActivityPage = browser.page.bluePipelineActivity().forJob(jobName, 'jenkins');
         blueActivityPage.waitForRunRunningVisible(jobName + '-1');
         const blueRunDetailPage = browser.page.bluePipelineRunDetail().forRun(jobName, 'jenkins', 1);
+        blueRunDetailPage.waitForJobRunEnded(jobName);
         blueRunDetailPage.closeModal('/activity');
     },
 };


### PR DESCRIPTION
# Description
- Add a regression test for the scenario when a user deep-links to run details with no tab specified in the URL.
- Added a new "waitForLocationChange" custom command that polls for a URL change and only allows the actions to proceed once it changes. Important for things like closing the modal that trigger an async location change
- See [JENKINS-40662](https://issues.jenkins-ci.org/browse/JENKINS-40662).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
