### PR TITLE
bug / flaky multibranch test results test

### DIFF
--- a/src/test/js/multibranch/testResults.js
+++ b/src/test/js/multibranch/testResults.js
@@ -40,6 +40,7 @@ module.exports = {
         blueRunDetailsPage.clickTab('tests');
 
         // Expand the test.
+        browser.useXpath().waitForElementVisible('//div[@class="result-item-head"]');
         browser.useXpath().click('//div[@class="result-item-head"]');
 
         browser.useXpath().waitForElementVisible('//div[@class="test-console"]/h4')


### PR DESCRIPTION
# Description
- This is an attempt to stabilize a test that was failing for me frequently (but not *every* time) while testing changes in #93 (see console output below). After clicking the tests tab I think we need an implicit wait before trying to click the element, as it will take a little time to render. Before this change, the test would fail about 50% of the time when running in `--dev` mode. After my change, it passed five times in a row without failure.

```
2017-01-04 13:29:47,570 [Thread-3] INFO   (InputStreamHandler.java:47) com.github.eirslett.maven.plugins.frontend.lib.DefaultGulpRunner - ERROR: Unable to locate element: "//div[@class="result-item-head"]" using: xpath
2017-01-04 13:29:47,570 [Thread-3] INFO   (InputStreamHandler.java:47) com.github.eirslett.maven.plugins.frontend.lib.DefaultGulpRunner -     at Object.module.exports.Check that the tests tab displays correctly (/Users/cmeyers/Development/code/blueocean-acceptance-test/src/test/js/multibranch/testResults.js:43:28)
2017-01-04 13:29:47,570 [Thread-3] INFO   (InputStreamHandler.java:47) com.github.eirslett.maven.plugins.frontend.lib.DefaultGulpRunner -     at _combinedTickCallback (internal/process/next_tick.js:67:7)
2017-01-04 13:29:47,570 [Thread-3] INFO   (InputStreamHandler.java:47) com.github.eirslett.maven.plugins.frontend.lib.DefaultGulpRunner -     at process._tickCallback (internal/process/next_tick.js:98:9)
```



# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
