### PR TITLE
[FIX JENKINS-39842] Open Blue Ocean button should not try to load /activity for a folder

### DIFF
--- a/src/main/js/page_objects/classic_jenkins/classicGeneral.js
+++ b/src/main/js/page_objects/classic_jenkins/classicGeneral.js
@@ -1,0 +1,24 @@
+/**
+ * @module classicGeneral
+ * @memberof page_objects
+ * @description Represents a page object containing "general" operations
+ * that can be performed on any Jenkins Classic page.
+ */
+
+exports.elements = {
+    pageBody: '#page-body'
+};
+exports.commands = [
+    {
+        /**
+         * Navigate to a page.
+         * @param {string} pageUrl Relative page URL (relative to nightwatch launchUrl).
+         * @returns {Object} self - nightwatch page object
+         */
+        navigateToRun: function(pageUrl) {
+            this.navigate(this.api.launchUrl + '/' + pageUrl);
+            this.waitForElementPresent('@pageBody');
+            return this;
+        }
+    }
+];

--- a/src/test/js/edgeCases/folder.js
+++ b/src/test/js/edgeCases/folder.js
@@ -204,4 +204,31 @@ module.exports = {
             blueRunDetailPage.assertBasicLayoutOkay();
         });
     },
+    /**
+     * test open blueocean from classic - a normal folder page in classic jenkins.
+     * <p>
+     * It should send the user to the top level blue ocean page (pipelines).
+     * @param browser
+     */
+    'step 11': function(browser) {
+        var classicGeneral = browser.page.classicGeneral();
+
+        // Go to a folder along the path to the MBP, but one
+        // of the parent folders i.e. not the MBP project folder.
+        classicGeneral.navigateToRun('job/anotherFolder/job/三百/job/ñba');
+
+        // make sure the open blue ocean button works. In this case,
+        // it should bring the browser to the main top-level pipelines page.
+        // See https://issues.jenkins-ci.org/browse/JENKINS-39842
+        browser.openBlueOcean();
+        browser.url(function (response) {
+            sanityCheck(browser, response);
+            response.value.endsWith('/blue/pipelines');
+
+            // Make sure the page has all the bits and bobs
+            // See JENKINS-40137
+            const bluePipelines = browser.page.bluePipelines();
+            bluePipelines.assertBasicLayoutOkay();
+        });
+    },
 };

--- a/src/test/js/edgeCases/folder.js
+++ b/src/test/js/edgeCases/folder.js
@@ -12,7 +12,7 @@
  * @see {@link https://issues.jenkins-ci.org/browse/JENKINS-36613|JENKINS-36613} Unable to load steps for multibranch pipelines with / in them
  * @see {@link https://issues.jenkins-ci.org/browse/JENKINS-36674|JENKINS-36674} Tests are not being reported
  * @see {@link https://issues.jenkins-ci.org/browse/JENKINS-36615|JENKINS-36615} the multibranch project has the branch 'feature/1'
- *
+ * @see {@link https://issues.jenkins-ci.org/browse/JENKINS-39842|JENKINS-39842} - Open Blue Ocean button should not try to load /activity for a folder
  *
  */
 const git = require("../../../main/js/api/git");
@@ -210,7 +210,7 @@ module.exports = {
      * It should send the user to the top level blue ocean page (pipelines).
      * @param browser
      */
-    'step 11': function(browser) {
+    'step 12': function(browser) {
         var classicGeneral = browser.page.classicGeneral();
 
         // Go to a folder along the path to the MBP, but one

--- a/src/test/js/multibranch/folder.js
+++ b/src/test/js/multibranch/folder.js
@@ -1,0 +1,107 @@
+/** @module folder
+ * @memberof multibranch
+ * @description
+ *
+ * Tests: Tests specific to MBP in folders
+ *
+ * REGRESSION covered:
+ *
+ * @see {@link https://issues.jenkins-ci.org/browse/JENKINS-39842|JENKINS-39842} - Open Blue Ocean button should not try to load /activity for a folder
+ *
+ */
+const git = require("../../../main/js/api/git");
+const path = require("path");
+const pageHelper = require("../../../main/js/util/pageHelper");
+const sanityCheck = pageHelper.sanityCheck;
+
+// base configuration for the path of the folders
+const projectFolderPath = ['aFolder', 'bFolder', 'cFolder'];
+//  our job should be named the same way in both folders
+const jobName = 'MBPInFolderTree';
+// git repo details
+const pathToRepo = path.resolve('./target/test-project-folder');
+const soureRep = './src/test/resources/multibranch_1';
+
+module.exports = {
+    /**
+     * creating a git repo
+     */
+    before: function (browser, done) {
+        browser.waitForJobDeleted('aFolder', function () {
+            // we creating a git repo in target based on the src repo (see above)
+            git.createRepo(soureRep, pathToRepo)
+                .then(function () {
+                    git.createBranch('feature/1', pathToRepo)
+                        .then(done);
+                });
+        });
+    },
+    /**
+     * Create folder structure - "aFolder/bFolder/cFolder"
+     */
+    'step 01': function (browser) {
+        // Initial folder create page
+        const folderCreate = browser.page.folderCreate().navigate();
+        // create nested folder for the project
+        folderCreate.createFolders(projectFolderPath);
+    },
+    /**
+     * Create multibranch job - "MBPInFolderTree"
+     */
+    'step 02': function (browser) {
+        // go to the newItem page
+        browser.page.jobUtils().newItem();
+        // and then use the multibranchCreate page object to create
+        // a multibranch project
+        browser.page.multibranchCreate().createBranch(jobName, pathToRepo);
+    },
+    /**
+     * test open blueocean from classic - run details
+     * @param browser
+     */
+    'step 03': function(browser) {
+        var classicRunPage = browser.page.classicRun();
+
+        classicRunPage.navigateToRun('aFolder/job/bFolder/job/cFolder/job/MBPInFolderTree/job/master');
+
+        // make sure the open blue ocean button works. In this case,
+        // it should bring the browser to the run details page for the first run.
+        browser.openBlueOcean();
+        browser.url(function (response) {
+           sanityCheck(browser, response);
+           response.value.endsWith('/blue/organizations/jenkins/aFolder%2FbFolder%2FcFolder%2FMBPInFolderTree/branches/');
+
+            // Make sure the page has all the bits and bobs
+            // See JENKINS-40137
+            const blueRunDetailPage = browser.page.bluePipelineRunDetail();
+            blueRunDetailPage.assertBasicLayoutOkay();
+        });
+    },
+    /**
+     * test open blueocean from classic - a normal folder page in classic jenkins.
+     * <p>
+     * It should send the user to the top level blue ocean page (pipelines).
+     * @param browser
+     */
+    'step 04': function(browser) {
+        var classicGeneral = browser.page.classicGeneral();
+
+        // Go to a folder along the path to the MBP, but one
+        // of the parent folders i.e. not the MBP project folder.
+        classicGeneral.navigateToRun('job/aFolder/job/bFolder');
+
+        // make sure the open blue ocean button works. In this case,
+        // it should bring the browser to the main top-level pipelines page.
+        // See https://issues.jenkins-ci.org/browse/JENKINS-39842
+        browser.openBlueOcean();
+        browser.url(function (response) {
+            sanityCheck(browser, response);
+            response.value.endsWith('/blue/pipelines');
+
+            // Make sure the page has all the bits and bobs
+            // See JENKINS-40137
+            const bluePipelines = browser.page.bluePipelines();
+            bluePipelines.assertBasicLayoutOkay();
+        });
+    },
+};


### PR DESCRIPTION
# Description

Test for https://github.com/jenkinsci/blueocean-plugin/pull/685

Clicking on the "Open Blue Ocean" button while in a classic folder that's not a MBP project folder should bring the user to the main top-level blue ocean page i.e. pipelines

See [JENKINS-39842](https://issues.jenkins-ci.org/browse/JENKINS-39842).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
