### PR TITLE
Declarative plugin 0.8.1 doesn't allow 'agent label: '''

### DIFF
--- a/src/test/resources/test_scripts/stages-with-wait-pipelineModel-syntax.groovy
+++ b/src/test/resources/test_scripts/stages-with-wait-pipelineModel-syntax.groovy
@@ -1,5 +1,5 @@
 pipeline {
-  agent label:""
+  agent any
   stages {
     stage ('Stage 1'){
       steps{


### PR DESCRIPTION
# Description

Fixes incompatible syntax with declarative 0.8.1.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
