### PR TITLE
eliminate some problematic waits and use "new" retry feature

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,9 +9,9 @@ const jsdoc = require('gulp-jsdoc3');
 const config = require('./jsdocConfig.json');
 
 if (process.argv.length === 4 && process.argv[2] === '--test') {
-    gulp.task('default', shell.task('nightwatch --retries 4 --suiteRetries 2 ' + process.argv[3].toString()));
+    gulp.task('default', shell.task('nightwatch --retries 5 --suiteRetries 2 ' + process.argv[3].toString()));
 } else {
-    gulp.task('default', shell.task('nightwatch --retries 4 --suiteRetries 2'));
+    gulp.task('default', shell.task('nightwatch --retries 5 --suiteRetries 2'));
 }
 
 gulp.task('doc', function (cb) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,9 +9,9 @@ const jsdoc = require('gulp-jsdoc3');
 const config = require('./jsdocConfig.json');
 
 if (process.argv.length === 4 && process.argv[2] === '--test') {
-    gulp.task('default', shell.task('nightwatch --suiteRetries 2 ' + process.argv[3].toString()));
+    gulp.task('default', shell.task('nightwatch --retries 4 --suiteRetries 2 ' + process.argv[3].toString()));
 } else {
-    gulp.task('default', shell.task('nightwatch --suiteRetries 2'));
+    gulp.task('default', shell.task('nightwatch --retries 4 --suiteRetries 2'));
 }
 
 gulp.task('doc', function (cb) {

--- a/src/test/js/failing.js
+++ b/src/test/js/failing.js
@@ -36,31 +36,33 @@ module.exports = {
     // now testing JENKINS-37666
     'Step 03': function (browser) {
         const blueRunDetailPage = browser.page.bluePipelineRunDetail().forRun(JOB, 'jenkins', 1);
+        
+        blueRunDetailPage.waitForElementVisible('.BasicHeader--failure');
         // we want to analyse the result after the job has finished
-        browser.waitForJobRunEnded(JOB, function() {
-            // the failure should collapse
-            blueRunDetailPage.clickFirstResultItemFailure(false);
-            // test whether the expand works
-            blueRunDetailPage.clickFirstResultItem();
-            // now click again so the result collapse again
-            blueRunDetailPage.clickFirstResultItem(false);
-            // now click the node again and see whether only one code is visible
-            blueRunDetailPage.clickFirstResultItem();
-            // we now need to get all visible code blocks, but there should be no more then one
-            browser.elements('css selector', 'pre', function (codeCollection) {
-                this.assert.equal(typeof codeCollection, "object");
-                this.assert.equal(codeCollection.status, 0);
-                // JENKINS-36700 in fail all code should be closed besides one
-                // however if the browser is too quick there can still be two open
-                this.assert.equal(codeCollection.value.length <= 2, true);
-            });
-            
-            // as it has failed, should get a replay button
-            blueRunDetailPage.waitForElementVisible('.replay-button');
-            
+        
+        // the failure should collapse
+        blueRunDetailPage.clickFirstResultItemFailure(false);
+        // test whether the expand works
+        blueRunDetailPage.clickFirstResultItem();
+        // now click again so the result collapse again
+        blueRunDetailPage.clickFirstResultItem(false);
+        // now click the node again and see whether only one code is visible
+        blueRunDetailPage.clickFirstResultItem();
+        // we now need to get all visible code blocks, but there should be no more then one
+        browser.elements('css selector', 'pre', function (codeCollection) {
+            this.assert.equal(typeof codeCollection, "object");
+            this.assert.equal(codeCollection.status, 0);
+            // JENKINS-36700 in fail all code should be closed besides one
+            // however if the browser is too quick there can still be two open
+            this.assert.equal(codeCollection.value.length <= 2, true);
+        });
+        
+        // as it has failed, should get a replay button
+        blueRunDetailPage.waitForElementVisible('.replay-button');
+        
             
 
-        });
+        
         
     },
     

--- a/src/test/js/failingStages.js
+++ b/src/test/js/failingStages.js
@@ -36,27 +36,28 @@ module.exports = {
     // now testing JENKINS-37666
     'Step 03': function (browser) {
         const blueRunDetailPage = browser.page.bluePipelineRunDetail().forRun(JOB, 'jenkins', 1);
+        blueRunDetailPage.waitForElementVisible('.BasicHeader--failure');
         // we want to analyse the result after the job has finished
-        browser.waitForJobRunEnded(JOB, function() {
-            // the failure should collapse
-            blueRunDetailPage.clickFirstResultItemFailure(false);
-            // test whether the expand works
-            blueRunDetailPage.clickFirstResultItem();
-            // now click again so the result collapse again
-            blueRunDetailPage.clickFirstResultItem(false);
-            // now click the node again and see whether only one code is visible
-            blueRunDetailPage.clickFirstResultItem();
-            // we now need to get all visible code blocks, but there should be no more then one
-            browser.elements('css selector', 'pre', function (codeCollection) {
-                this.assert.equal(typeof codeCollection, "object");
-                this.assert.equal(codeCollection.status, 0);
-                // JENKINS-36700 in fail all code should be closed besides one
-                // however if the browser is too quick there can still be two open
-                this.assert.equal(codeCollection.value.length <= 2, true);
-            });
+        
+        // the failure should collapse
+        blueRunDetailPage.clickFirstResultItemFailure(false);
+        // test whether the expand works
+        blueRunDetailPage.clickFirstResultItem();
+        // now click again so the result collapse again
+        blueRunDetailPage.clickFirstResultItem(false);
+        // now click the node again and see whether only one code is visible
+        blueRunDetailPage.clickFirstResultItem();
+        // we now need to get all visible code blocks, but there should be no more then one
+        browser.elements('css selector', 'pre', function (codeCollection) {
+            this.assert.equal(typeof codeCollection, "object");
+            this.assert.equal(codeCollection.status, 0);
+            // JENKINS-36700 in fail all code should be closed besides one
+            // however if the browser is too quick there can still be two open
+            this.assert.equal(codeCollection.value.length <= 2, true);
+        });
             
 
-        });
+        
         
     },
     

--- a/src/test/js/log-karaoke/input.js
+++ b/src/test/js/log-karaoke/input.js
@@ -25,9 +25,9 @@ module.exports = {
     'Step 03': function (browser) {
         const blueActivityPage = browser.page.bluePipelineActivity().forJob(jobName, 'jenkins');
         // Check the run is turning to pause
-        blueActivityPage.waitForJobRunPaused(jobName, function () {
-            blueActivityPage.waitForRunPausedVisible(jobName + '-1');
-        });
+        blueActivityPage.waitForElementVisible('.circle-bg.paused');        
+        blueActivityPage.waitForRunPausedVisible(jobName + '-1');
+        
     },
     /** Check Job Blue Ocean Pipeline Activity Page has run  - then go to the detail page and validate the input form
      * */
@@ -38,9 +38,8 @@ module.exports = {
         // submit the form
         blueRunDetailPage.click('@inputStepSubmit');
         // Check the run is turning to unpaused
-        blueRunDetailPage.waitForJobRunUnpaused(jobName, function () {
-            // wait for job to finish
-            blueRunDetailPage.waitForJobRunEnded(jobName);
-        });
+        
+        blueRunDetailPage.waitForElementNotPresent('.circle-bg.paused');
+        blueRunDetailPage.waitForElementVisible('.circle-bg.success');
     }
 };

--- a/src/test/js/log-karaoke/input.js
+++ b/src/test/js/log-karaoke/input.js
@@ -40,6 +40,6 @@ module.exports = {
         // Check the run is turning to unpaused
         
         blueRunDetailPage.waitForElementNotPresent('.circle-bg.paused');
-        blueRunDetailPage.waitForElementVisible('.circle-bg.success');
+        blueRunDetailPage.waitForElementVisible('.BasicHeader--success');
     }
 };


### PR DESCRIPTION
This works around the missing events, so it doesn't hang. 

Also uses the nightwatch "retry" to retry just test runs, not whole suite. 

MOTHER OF GOD this may work. 

So this is 2 parts: 

1) work around the missing events (event source problem)
2) do retries at the test level, not suite (that seems a new-ish nightwatch feature, well I just found it). 


@reviewbybees @tfennelly 
Has worked a few times in a row now, after nothing else working for days. 