### PR TITLE
Remove blueocean runtime dependencies

### DIFF
--- a/runtime-deps/pom.xml
+++ b/runtime-deps/pom.xml
@@ -58,17 +58,6 @@
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
     </properties>
-    <dependencies>
-        <!--
-        Add dependencies that all of our tests need, but are not provided via
-        the Blue Ocean Aggregator plugin.
-        -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <version>2.4</version>
-        </dependency>
-    </dependencies>
     <profiles>
         <profile>
             <id>with-blueocean-deps</id>

--- a/src/test/js/edgeCases/initialStage.js
+++ b/src/test/js/edgeCases/initialStage.js
@@ -24,7 +24,6 @@ module.exports = {
     pipelinePage.buildStarted(function () {
       // Reload the job page and check that there was a build started.
       pipelinePage
-        .waitForElementVisible('div#pipeline-box')
         .forRun(1)
         .waitForElementVisible('@executer');
     });

--- a/src/test/js/failing.js
+++ b/src/test/js/failing.js
@@ -24,7 +24,6 @@ module.exports = {
         pipelinePage.buildStarted(function() {
             // Reload the job page and check that there is a build started.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });

--- a/src/test/js/failingStages.js
+++ b/src/test/js/failingStages.js
@@ -24,7 +24,6 @@ module.exports = {
         pipelinePage.buildStarted(function() {
             // Reload the job page and check that there is a build started.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });

--- a/src/test/js/log-karaoke/input.js
+++ b/src/test/js/log-karaoke/input.js
@@ -16,7 +16,6 @@ module.exports = {
         pipelinePage.buildStarted(function() {
             // Reload the job page and check that there was a build done.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });

--- a/src/test/js/log-karaoke/noStages.js
+++ b/src/test/js/log-karaoke/noStages.js
@@ -15,7 +15,6 @@ module.exports = {
         pipelinePage.buildStarted(function() {
             // Reload the job page and check that there was a build done.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });

--- a/src/test/js/log-karaoke/parallelStages.js
+++ b/src/test/js/log-karaoke/parallelStages.js
@@ -20,7 +20,6 @@ module.exports = {
         pipelinePage.buildStarted(function () {
             // Reload the job page and check that there was a build done.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });

--- a/src/test/js/log-karaoke/parametrisedPipeline.js
+++ b/src/test/js/log-karaoke/parametrisedPipeline.js
@@ -58,7 +58,6 @@ module.exports = {
     pipelinePage.buildStarted(function () {
       // Reload the job page and check that there was a build done.
       pipelinePage
-        .waitForElementVisible('div#pipeline-box')
         .forRun(1)
         .waitForElementVisible('@executer');
     });

--- a/src/test/js/log-karaoke/stages-block.js
+++ b/src/test/js/log-karaoke/stages-block.js
@@ -31,7 +31,6 @@ module.exports = {
         pipelinePage.buildStarted(function() {
             // Reload the job page and check that there was a build done.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });

--- a/src/test/js/log-karaoke/stages-new.js
+++ b/src/test/js/log-karaoke/stages-new.js
@@ -31,7 +31,6 @@ module.exports = {
         pipelinePage.buildStarted(function() {
             // Reload the job page and check that there was a build done.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });

--- a/src/test/js/log-karaoke/stages-old.js
+++ b/src/test/js/log-karaoke/stages-old.js
@@ -36,7 +36,6 @@ module.exports = {
         pipelinePage.buildStarted(function() {
             // Reload the job page and check that there was a build done.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });

--- a/src/test/js/runDetailsModal/runDetailsFallbackNavigation.js
+++ b/src/test/js/runDetailsModal/runDetailsFallbackNavigation.js
@@ -21,7 +21,6 @@ module.exports = {
         pipelinePage.buildStarted(function () {
             // Reload the job page and check that there was a build done.
             pipelinePage
-                .waitForElementVisible('div#pipeline-box')
                 .forRun(1)
                 .waitForElementVisible('@executer');
         });


### PR DESCRIPTION
# Description

Removes dependency on workflow-aggregator plugin. It was needed only because some tests were testing stage view UI's div#pipeline-box element. It's not really needed, will be good to clean this up.

ATH passes https://ci.blueocean.io/blue/organizations/jenkins/ATH-Jenkinsfile/detail/remove-blueocean-runtime-dependencies/4/pipeline.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 