### PR TITLE
Seriously javascript is terrible

### DIFF
--- a/src/test/js/log-karaoke/noStages.js
+++ b/src/test/js/log-karaoke/noStages.js
@@ -90,7 +90,7 @@ module.exports = {
             this
                 .elements('css selector', 'div.result-item.success', function (collection2) {
                     const count2 = collection2.value.length;
-                    this.assert.notEqual(count, count2);
+                    this.assert.equal(count !== count2, true);
                 })
                 .elements('css selector', 'pre', function (codeCollection) {
                     // JENKINS-36700 in success all code should be closed,


### PR DESCRIPTION
You can't trust js and equals - I have no idea what these cockamimie assertion functions do with types, but it has done stupiud things 

This may be simpler...

what it did: 

```
06:19:46 INFO  -    - Step 04 (4.381s)
06:19:46 INFO  -    Failed [notEqual]: (0 != 0)  - expected "0" but got: "0"
```
which is idiotic. Obviously 0 != 0 is false, but then the message it prints? WTAF? 
The test I think is just expecting that the counts are different after some time(??). In the failure case they were not, but then it says "expected 0 but got 0" ...

I am not sure why this test assertion code is so bad, I can't understand any of it. 

cc @imeredith @sophistifunk 